### PR TITLE
Corrections & improvements to Dylan macro system article.

### DIFF
--- a/source/articles/macro-system/faq-tips.rst
+++ b/source/articles/macro-system/faq-tips.rst
@@ -76,7 +76,7 @@ common BNF forms.
            { z ... }
            { }
 
-`{x}? | {x}(, {x})*`
+`{x}? | {x} (, {x})*`
       This is a list that may have 0–*n* items. Handle this by calling out to an
       auxiliary rule that calls itself recursively like so::
       
@@ -89,7 +89,7 @@ common BNF forms.
       variable needs to be well-separated from the syntax that follows it by a
       semicolon or intermediate word.
 
-`{x}(, {x})*`
+`{x} (, {x})*`
       This is a list that may have 1–*n* items. You simply cannot do this in the
       general case; your best bet is design your macro to handle 0 items
       gracefully and then use a 0-*n* list.

--- a/source/articles/macro-system/macro-types.rst
+++ b/source/articles/macro-system/macro-types.rst
@@ -66,7 +66,7 @@ syntax, with optional parts in brackets::
       `my-aux-ruleset:` or `#"my-aux-ruleset"`; both are the same.
 
       
-.. _`main-rules`:
+.. _main-rules:
 
 Main rules
 ==========

--- a/source/articles/macro-system/pattern-variables.rst
+++ b/source/articles/macro-system/pattern-variables.rst
@@ -33,8 +33,6 @@ a given inner macro. An example of this is given in the discussion of the
 The scope of a pattern variable is the rule that uses it. Other rules or
 auxiliary rule sets cannot use the pattern variable.
 
-What follows is a categorized list of pattern variable syntaxes.
-
 
 Simple pattern variables
 ========================
@@ -46,14 +44,15 @@ Simple pattern variables
         This is a pattern variable where its constraint is also its name. For
         example, `?:expression` is equivalent to `?expression:expression`,
         that is, a pattern variable named `expression` with a constraint of
-        `expression.`
+        `expression`.
 
 `?{name}:name`
         This matches a name.
 
 `?{name}:token`
-        This matches a name, operator, or simple literal such as a string, character,
-        or number. It does not match vector literals or function calls.
+        This matches a name, operator, or simple literal such as a string,
+        character constant, or number. It does not match vector literals or
+        function calls.
 
 `?{name}:expression`
         This matches any expression, including vector literals, function calls,
@@ -65,10 +64,11 @@ Simple pattern variables
 
 `?{name}:name :: ?{specialization}:expression`
         This matches a variable name and optional specialization, like
-        `?:variable`, but lets you get each part. If the code fragment just
-        has the name part, the substitution for `?{specialization}` will be
-        `<object>`. Note that `?{specialization}` will not match every expression. It
-        will only match an expression that happens to be a type specialization.
+        `?:variable`, but lets you extract each part separately. If the code
+        fragment just has the name part, the substitution for
+        `?{specialization}` will be `<object>`. Note that `?{specialization}`
+        will not match every expression; it will only match an expression that
+        happens to also be a valied type specialization.
 
 
 .. _proplist-variables:
@@ -84,21 +84,21 @@ Property list pattern variables
 
 `#key ?{prop-1}:{constraint}, ?{prop-2}:{constraint}`
         This matches a property list that only includes the `{prop-1}:` and
-        `{prop-2}:` properties. If the property list includes any other
-        property such as `alpha:` or if either `{prop-1}:` or
-        `{prop-2}:` are missing, this pattern variable will not match.
-        Additionally, the properties' value parts have to meet the constraint.
-        If the constraint is `*`, any value part will match.
+        `{prop-2}:` properties. If the property list includes any other property
+        such as `alpha:` or if either `{prop-1}:` or `{prop-2}:` are missing,
+        this pattern variable will not match. Additionally, the properties'
+        value parts have to meet the constraints given. If the constraint is
+        `*`, any value part will match.
 
         The substitution for `?{prop-1}` is the value part of the `{prop-1}:`
         property.
 
 `#key ??{prop-1}:{constraint}, ??{prop-2}:{constraint}`
         This matches a property list that has several properties with a symbol
-        part of `{prop-1}:` or `{prop-2}:`. The substitution for
-        `??{prop-1}` is several code fragments, each being the value part of a
-        `{prop-1}:` property. The substitution may use a separator between each
-        code fragment as described in :doc:`substitutions`.
+        part of `{prop-1}:` or `{prop-2}:`. The substitution for `??{prop-1}` is
+        several code fragments, each being the value part of a `{prop-1}:`
+        property. The substitution may use one of the separators listed in
+        :ref:`finalitems-subst` between each code fragment.
 
         For example, consider this pattern::
 
@@ -124,7 +124,7 @@ Property list pattern variables
 
                 my-key: alpha, another-key: beta
 
-        This pattern would not match it::
+        This pattern would not match::
         
                 { #key ?my-key:name }
 
@@ -167,8 +167,8 @@ Body and macro pattern variables
         substitution will be `#f`. The substitution will wrap the code
         fragment in `begin` and `end` to make an expression.
 
-        A `?:body` pattern variable matches statements and expressions in a
-        code fragment until it reaches some word, called an `intermediate word`.
+        A `?:body` pattern variable matches statements and expressions in a code
+        fragment until it reaches some word, called an `intermediate word`:dfn:.
         You must ensure that all your `?:body` pattern variables are either
         followed by a word, or followed by a pattern variable referring to an
         auxiliary rule set whose rules all start with a word. Those word will
@@ -188,8 +188,8 @@ Body and macro pattern variables
                 { endif }
                 { else ?:body endif }
 
-        In this example, the macro will not work because the `?:body` variable
-        is not necessarily followed by a word::
+        In this example, the macro will not work because the pattern does not
+        include an intermediate word following the `?:body` variable::
 
                 { when (?:expression) ?:body }
 
@@ -236,10 +236,9 @@ Body and macro pattern variables
         macro, without the begin…end block that normally surrounds macro
         expansions.
 
-        While you can use the `?:expression` and `?:body` pattern variable
-        constraints to match function and statement macro calls, they cannot
-        match definition macro calls, and their substitutions will include the
-        begin…end wrapper.
+        While you can use `?:expression` and `?:body` pattern variables to match
+        macro calls, their substitutions will include a called macro's begin…end
+        wrapper, and `?:expression` can only match function macro calls.
 
 
 .. _wildcard-variables:
@@ -254,14 +253,15 @@ Wildcard pattern variables
 
                 { ?many-things:* ?:name }
 
-        `?many-things` will match everything up to but not including a name.
-        The substitution for `?many-things` will be everything except that
-        name name. If the code fragment only has a name, the substitution will
-        be empty.
+        `?many-things` will match everything up to but not including a name. The
+        substitution for `?many-things` will be everything except that name. If
+        the code fragment only has a name, the substitution for `?many-things`
+        will be empty.
 
-        There can only be one wildcard pattern variable in a sub-pattern. Each
-        must be separated from other wildcard variables by a semicolon or comma.
-        For example, this is not a legal pattern::
+        There can only be one wildcard pattern variable in a comma- or
+        semicolon-separated sub-pattern. Each must be separated from other
+        wildcards by a semicolon or comma. For example, this is not a legal
+        pattern::
 
                 { ?first:* ?second:* }
 
@@ -295,10 +295,10 @@ Wildcard pattern variables
 Auxiliary rule set pattern variables
 ====================================
 
-`?my-aux-rules`
+`?{aux-rules}`
         This syntax can only be used when there is an auxiliary rule set named
-        the same as the pattern variable. It is equivalent to
-        `?my-aux-rule:*`. See :doc:`auxiliary-rules`.
+        the same as the pattern variable. It is equivalent to `?{aux-rules}:*`.
+        See :doc:`auxiliary-rules`.
 
 `...`
         This syntax can only be used within an auxiliary rule set. If the rule

--- a/source/articles/macro-system/patterns.rst
+++ b/source/articles/macro-system/patterns.rst
@@ -80,16 +80,16 @@ Final items
 ===========
 
 A pattern with at least two list items treats the last item specially. For
-example, the pattern `Pattern 1`_ will match any of `Code Fragments`_ and set
-and set the pattern variables as follows:
+example, the pattern `Pattern 1`_ will match any of `Code Fragments`_, and will
+set the pattern variables as follows:
 
-========  =======  =======  =======================
-Fragment  ?item-1  ?item-2  ?item-3
-========  =======  =======  =======================
-Line 1    `alpha`  `beta`   `gamma`
-Line 2    `alpha`  `beta`   
-Line 3    `alpha`  `beta`   `gamma, delta, epsilon`
-========  =======  =======  =======================
+==============  =======  =======  =======================
+Code Fragments  ?item-1  ?item-2  ?item-3
+==============  =======  =======  =======================
+Line 1          `alpha`  `beta`   `gamma`
+Line 2          `alpha`  `beta`   
+Line 3          `alpha`  `beta`   `gamma, delta, epsilon`
+==============  =======  =======  =======================
 
 This special behavior is usually only relevant when the last item in the list is
 a wildcard pattern variable (see :ref:`wildcard-variables`). If the pattern were
@@ -131,23 +131,6 @@ The end of a comma-separated list of pattern fragments can include `#rest`,
 
         { …, #rest ?keys:token, #key ?alpha:token, ?beta:token, #all-keys }
 
-If you write a pattern that contains `#all-keys`, you must also include `#key`.
-There are several variations on this syntax; they are described in
-:ref:`proplist-variables`.
-
-`#rest`, `#key`, and `#all-keys` must be the only pattern fragments in their
-comma-separated sub-pattern, and that sub-pattern must be the last of several
-comma-separated sub-patterns. Here are some examples of when it is or is not
-valid to use this syntax in a pattern::
-
-        /* valid */   { #key ?alpha:token }
-        /* invalid */ { ?alpha:token #key ?beta:token }
-        /* valid */   { ?anything:*, #key ?alpha:token, #all-keys }
-        /* invalid */ { #key ?alpha:token, #all-keys, ?anything:* }
-        /* valid */   { #key ?alpha:token, #all-keys; ?anything:* }
-        /* invalid */ { #key ?alpha:token, #key ?beta-token }
-        /* valid */   { #key ?alpha:token; #key ?beta-token }
-
 This syntax is not used to match a code fragment that contains corresponding
 literal `#rest`, `#key`, and `#all-keys` fragments. Instead, this syntax
 matches a code fragment consisting of keyword/value pairs, called a `property
@@ -160,3 +143,20 @@ property list and `"a"` and `"b"` are the value parts.
 
 If you want to match literal `#rest`, `#key`, or `#all-keys` fragments, escape
 them in the pattern like `\#rest`, `\#key`, or `\#all-keys`.
+
+If you write a pattern that contains `#all-keys`, you must also include `#key`.
+There are several variations on this syntax; they are described in
+:ref:`proplist-variables`.
+
+`#rest`, `#key`, and `#all-keys` must be the only pattern fragments in their
+comma-separated sub-pattern, and that sub-pattern must be the last of several
+comma-separated sub-patterns. Here are some examples of when it **is** or **is
+not** valid to use this syntax in a pattern::
+
+        /* valid */     { #key ?alpha:token }
+        /* not valid */ { ?alpha:token #key ?beta:token }
+        /* valid */     { ?anything:*, #key ?alpha:token, #all-keys }
+        /* not valid */ { #key ?alpha:token, #all-keys, ?anything:* }
+        /* valid */     { #key ?alpha:token, #all-keys; ?anything:* }
+        /* not valid */ { #key ?alpha:token, #key ?beta-token }
+        /* valid */     { #key ?alpha:token; #key ?beta-token }

--- a/source/articles/macro-system/substitutions.rst
+++ b/source/articles/macro-system/substitutions.rst
@@ -18,10 +18,16 @@ Substitutions
 
 Pattern variables contain code fragments, which can be inserted into the macro
 expansion via a substitution. A substitution looks much like a pattern variable,
-but it are on the template side of the rule and has different syntax forms.
+but it is on the template side of the rule and has different syntax forms.
 
 A template can only use pattern variables from its corresponding pattern. It
 cannot use pattern variables from other rules' patterns.
+
+
+.. _finalitems-subst:
+
+Final items
+===========
 
 As a special case, if the template has a separator followed by any of the
 substitution forms below, and the substituted code fragment is empty, the
@@ -69,12 +75,12 @@ Conversion substitutions
 ========================
 
 `?#"{name}"`
-        The pattern variable's code fragment, which must be a simple name, is
-        turned into a symbol and inserted into the expansion.
+        The code fragment of the pattern variable `{name}`, which must be a
+        simple name, is turned into a symbol and inserted into the expansion.
 
 `?"{name}"`
-        The pattern variable's code fragment, which must be a simple name, is
-        turned into a string and inserted into the expansion.
+        The code fragment of the pattern variable `{name}`, which must be a
+        simple name, is turned into a string and inserted into the expansion.
 
 
 Concatenation substitutions
@@ -105,7 +111,13 @@ Concatenation substitutions
                 "alpha-function"
                 
 `"{prefix}" ## ?#"{name}" ## "{suffix}"`
-        As above, but results in a symbol.
+        As above, but results in a symbol::
+        
+                #"alpha-function"
+                
+        Or, equivalently::
+        
+                alpha-function:
 
 
 List substitutions
@@ -140,8 +152,8 @@ List substitutions
 
                 alpha
 
-        Any of the separators [seps]_ may be used in place of a comma in the
-        tempate.
+        Any of the separators `Separators`_ may be used in place of a comma in
+        the tempate.
 
 
 Auxiliary rule set substitution


### PR DESCRIPTION
Corrects typos, bad links, and some misinformation about macro calls in ?:body and ?:expression code fragments.
Improves discussion of complex auxiliary rules and hygiene and misinformation about hygiene of definitions.
