### PR TITLE
Website: Fix broken links to 'old docs' in index page

### DIFF
--- a/source/documentation/index.rst
+++ b/source/documentation/index.rst
@@ -69,7 +69,7 @@ Learning Dylan
     and editor integration (like emacs). This is mainly useful for
     people using Open Dylan on Linux, FreeBSD and Mac OS X.
 
-`Getting Started with the Open Dylan IDE <getting-started-ide/index.html>`_ [`pdf <getting-started-ide/GettingStartedWithTheOpenDylanIDE.pdf>`__] [`epub <getting-started-ide/GettingStartedWithTheOpenDylanIDE.epub>`__] [`old HTML <http://opendylan.org/documentation/opendylan/env/index.htm>`__]
+`Getting Started with the Open Dylan IDE <getting-started-ide/index.html>`_ [`pdf <getting-started-ide/GettingStartedWithTheOpenDylanIDE.pdf>`__] [`epub <getting-started-ide/GettingStartedWithTheOpenDylanIDE.epub>`__] [`old HTML <http://web.archive.org/web/20170102232752/http://opendylan.org/documentation/opendylan/env/index.htm>`__]
     Describes Open Dylan's integrated development environment which
     is available for Windows.
 

--- a/source/documentation/index.rst
+++ b/source/documentation/index.rst
@@ -73,7 +73,7 @@ Learning Dylan
     Describes Open Dylan's integrated development environment which
     is available for Windows.
 
-`Building Applications Using DUIM <building-with-duim/index.html>`_ [`pdf <building-with-duim/BuildingApplicationsWithDUIM.pdf>`__] [`epub <building-with-duim/BuildingApplicationsWithDUIM.epub>`__] [`old HTML <http://opendylan.org/documentation/opendylan/dguide/index.htm>`__]
+`Building Applications Using DUIM <building-with-duim/index.html>`_ [`pdf <building-with-duim/BuildingApplicationsWithDUIM.pdf>`__] [`epub <building-with-duim/BuildingApplicationsWithDUIM.epub>`__] [`old HTML <http://web.archive.org/web/20170102232826/http://opendylan.org/documentation/opendylan/dguide/index.htm>`__]
     Describes how to use DUIM (Dylan User Interface Manager),
     the portable window programming toolkit. This is only useful
     if you are using Open Dylan on Windows.


### PR DESCRIPTION
Fix broken links to 'old docs' in Opendylan's website index page. Replace them with snapshot taken by 'web.archive.org'.