### PR TITLE
Fix typos

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ On a Debian-derivative, they're quite easy to fetch::
 Getting the source
 ------------------
 
-The next step is fetching the repository and the ::
+The next step is fetching the repository and its submodule::
 
     git clone https://github.com/dylan-lang/website.git  # or your fork
     git submodule update --init --recursive

--- a/source/index.rst
+++ b/source/index.rst
@@ -108,7 +108,7 @@
      <h2>Get Started</h2>
 
 `Downloading Dylan </download/index.html>`_  is easy.
-Once downloaded, we recommend reading through `Introduction to Dylan <https://opendylan.org/documentation/intro-dylan/>`_ and exploring `some examples <https://github.com/dylan-lang/opendylan/tree/master/sources/examples>`.
+Once downloaded, we recommend reading through `Introduction to Dylan <https://opendylan.org/documentation/intro-dylan/>`_ and exploring `some examples <https://github.com/dylan-lang/opendylan/tree/master/sources/examples>`_.
 
 .. raw:: html
 


### PR DESCRIPTION
Really sorry about this, but I've just spotted two errors in #93 and #94. On is an reStructuredText link syntax error and the other is an incomplete sentence in the README. This PR addresses them.