### PR TITLE
Fix layout when page width changes

### DIFF
--- a/source/_themes/opendylan/layout.html
+++ b/source/_themes/opendylan/layout.html
@@ -9,7 +9,6 @@
 {% block doctype %}
 <!DOCTYPE html>
 {% endblock %}
-{% set css_files = css_files + ['_static/opendylan.org/css/opendylan.css'] -%}
 {% set navigation_bar = [
     ('index', 'Home'),
     ('history/index', 'History'),

--- a/source/_themes/opendylan/static/opendylan.org/css/opendylan.css
+++ b/source/_themes/opendylan/static/opendylan.org/css/opendylan.css
@@ -63,6 +63,10 @@ blockquote div p {
   body {
     padding-top: 30px;
   }
+  /* Make code font smaller */
+  #code-carousel pre {
+      font-size: smaller;
+  }
 }
 
 @media (max-width: 768px) {

--- a/source/_themes/opendylan/theme.conf
+++ b/source/_themes/opendylan/theme.conf
@@ -1,2 +1,3 @@
 [theme]
 inherit = basic
+stylesheet = opendylan.org/css/opendylan.css

--- a/source/community/index.rst
+++ b/source/community/index.rst
@@ -1,6 +1,6 @@
 .. raw:: html
 
-  <div class="row">
+  <div class="row-fluid">
     <div class="span3 bs-docs-sidebar">
       <ul class="nav nav-list bs-docs-sidenav" data-spy="affix">
         <li><a href="#contribute"><i class="icon-chevron-right"></i> How to Contribute</a></li>

--- a/source/documentation/cheatsheets/iteration.rst
+++ b/source/documentation/cheatsheets/iteration.rst
@@ -11,7 +11,7 @@ Simple iteration with ``while`` and ``until``
 
 .. raw:: html
 
-   <div class="row">
+   <div class="row-fluid">
      <div class="span6">
 
 .. code-block:: dylan

--- a/source/documentation/index.rst
+++ b/source/documentation/index.rst
@@ -1,6 +1,6 @@
 .. raw:: html
 
-  <div class="row">
+  <div class="row-fluid">
     <div class="span3 bs-docs-sidebar">
       <ul class="nav nav-list bs-docs-sidenav" data-spy="affix">
         <li><a href="#cheat-sheets"><i class="icon-chevron-right"></i> Cheat Sheets</a></li>

--- a/source/history/index.rst
+++ b/source/history/index.rst
@@ -1,6 +1,6 @@
 .. raw:: html
 
-  <div class="row">
+  <div class="row-fluid">
     <div class="span3 bs-docs-sidebar">
       <ul class="nav nav-list bs-docs-sidenav" data-spy="affix">
         <li><a href="#apple-dylan"><i class="icon-chevron-right"></i> Apple Dylan</a></li>

--- a/source/index.rst
+++ b/source/index.rst
@@ -17,15 +17,15 @@
     slot owner :: <string>,
       init-keyword: owner:,
       init-value: "Northern Motors";
-  end class <vehicle>;
+  end;
 
   define class <car> (<vehicle>)
-  end class <car>;
+  end;
 
   define class <truck> (<vehicle>)
     slot capacity,
       required-init-keyword: tons:;
-  end class <truck>;
+  end;
 
 .. raw:: html
 
@@ -43,14 +43,14 @@
 
   define method tax
       (c :: <car>) => (tax-in-dollars :: <float>)
-    50.0;
-  end method;
+    50.0
+  end;
 
   define method tax
       (t :: <truck>) => (tax-in-dollars :: <float>)
     // standard vehicle tax plus $10/ton
-    next-method() + t.capacity * 10.0;
-  end method;
+    next-method() + t.capacity * 10.0
+  end;
 
 .. raw:: html
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -112,7 +112,7 @@ Once downloaded, we recommend reading through `Introduction to Dylan <https://op
 
 .. raw:: html
 
-     <h2>Learn about Dylan</h2>
+     <h2>Learn Dylan</h2>
 
 Dylan has a large amount of documentation available:
 

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,7 +1,16 @@
 .. raw:: html
 
-   <div class="row">
+   <div class="row-fluid">
+     <div class="span4">
+       <div class="well">
+	 <p>Dylan is a multi-paradigm functional and object-oriented programming language.
+	 It is dynamic while providing a programming model designed to support efficient
+	 machine code generation, including fine-grained control over dynamic and static
+	 behaviors.</p>
+       </div>
+     </div>
      <div class="span8">
+.. raw:: html
 
      <div id="code-carousel" class="carousel slide">
        <ol class="carousel-indicators">
@@ -81,14 +90,19 @@
        <a class="carousel-control left" href="#code-carousel" data-slide="prev">&lsaquo;</a>
        <a class="carousel-control right" href="#code-carousel" data-slide="next">&rsaquo;</a>
      </div>
-     <h2>Recent News</h2>
-
-     <div class="alert alert-block alert-info">
-       <p>Keep up to date by subscribing to our <a href="rss.xml">RSS
-       Feed <img src="_static/feed-icon-14x14.png" alt=""></a> or
-       joining our <a href="community/index.html#mailing-lists">mailing
-       lists</a>.</p>
      </div>
+
+   </div>
+   <div class="row-fluid">
+     <div class="span6">
+       <h2>Recent News</h2>
+
+       <div class="alert alert-block alert-info">
+         <p>Keep up to date by subscribing to our <a href="rss.xml">RSS
+         Feed <img src="_static/feed-icon-14x14.png" alt=""></a> or
+         joining our <a href="community/index.html#mailing-lists">mailing
+         lists</a>.</p>
+       </div>
 
 .. include:: news/recent.rst.inc
 
@@ -96,16 +110,8 @@
 
        <div class="pull-right"><a href="news/index.html">All news &raquo;</a></div>
      </div>
-     <div class="span4">
-
-     <div class="well">
-     <p>Dylan is a multi-paradigm functional and object-oriented programming language.
-     It is dynamic while providing a programming model designed to support efficient
-     machine code generation, including fine-grained control over dynamic and static
-     behaviors.</p>
-     </div>
-
-     <h2>Get Started</h2>
+     <div class="span6">
+       <h2>Get Started</h2>
 
 `Downloading Dylan </download/index.html>`_  is easy.
 Once downloaded, we recommend reading through `Introduction to Dylan <https://opendylan.org/documentation/intro-dylan/>`_ and exploring `some examples <https://github.com/dylan-lang/opendylan/tree/master/sources/examples>`_.
@@ -131,6 +137,7 @@ Dylan has a large amount of documentation available:
 .. raw:: html
 
      </div>
+     </div>
    </div>
 
 .. toctree::
@@ -144,3 +151,4 @@ Dylan has a large amount of documentation available:
    news/*/*/*/*
    community/gsoc/*
 
+.. -*- tab-width: 4 -*-

--- a/source/news/index.rst
+++ b/source/news/index.rst
@@ -4,7 +4,7 @@ News & Articles
 
 .. raw:: html
 
-   <div class="row">
+   <div class="row-fluid">
      <div class="span6">
 
      <h2>News</h2>


### PR DESCRIPTION
Previously, the responsive layout was causing the left navigation area to overlap the main content for wider page sizes.

Fixes #96 