### PR TITLE
Update documentation index with new publications

### DIFF
--- a/source/documentation/index.rst
+++ b/source/documentation/index.rst
@@ -168,7 +168,25 @@ Articles
 Publications
 ============
 
-**Extending Dylan's type system for better type inference and error detection** [`pdf <http://www.itu.dk/~hame/ilc2010.pdf>`__] [`bib <../_static/documentation/mehnert2010.bib>`__]
+**LLVM Code Generation for Open Dylan** (by Peter Housel at ELS 2020 `pdf <https://zenodo.org/record/3742567/files/els2020-opendylan.pdf?download=1>`__ `bib <../_static/documentation/housel_peter_s_2020_3742567.bib>`__ `slides <https://european-lisp-symposium.org/static/2020/housel-slides.pdf>`__ `video <https://www.youtube.com/watch?v=6dcrXBzw4H4>`__)
+  The Open Dylan compiler, DFMC, was originally designed in the 1990s
+  to compile Dylan language code targeting the 32-bit Intel x86
+  platform, or other platforms via portable C. As platforms have
+  evolved since, this approach has been unable to provide efficient
+  code generation for a broader range of target platforms, or to
+  adequately support tools such as debuggers, profilers, and code
+  coverage analyzers.
+
+  Developing a code generator for Open Dylan that uses the LLVM
+  compiler infrastructure is enabling us to support these goals and
+  modernize our implementation. This work describes the design
+  decisions and engineering trade-offs that have influenced the
+  implementation of the LLVM back-end and its associated run-time
+  support.
+
+  https://doi.org/10.5281/zenodo.3742567
+
+**Extending Dylan's type system for better type inference and error detection** (by Hannes Mehnert at ILC 2010 `pdf <http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.627.5175&rep=rep1&type=pdf>`__ `bib <../_static/documentation/mehnert2010.bib>`__)
     Whereas dynamic typing enables rapid prototyping and easy
     experimentation, static typing provides early error detection and
     better compile time optimization. Gradual typing provides the best
@@ -204,17 +222,7 @@ Publications
     components, multi-threaded runtime, incremental development, “pay
     as you go philosophy”, and interoperability with standard tools.
 
-**D-Expressions: Lisp Power, Dylan Style** [`pdf <http://people.csail.mit.edu/jrb/Projects/dexprs.pdf>`__] [`bib <../_static/documentation/bachrach1999.bib>`__]
-    This paper aims to demonstrate that it is possible for a language
-    with a rich, conventional syntax to provide Lisp-style macro power
-    and simplicity. We describe a macro system and syntax manipulation
-    toolkit designed for the Dylan programming language that meets,
-    and in some areas exceeds, this standard. The debt to Lisp is
-    great, however, since although Dylan has a conventional algebraic
-    syntax, the approach taken to describe and represent that syntax
-    is distinctly Lisp-like in philosophy.
-
-`See our publications page to find more <publications.html>`_.
+See the `publications <publications.html>`_ page for more.
 
 For Open Dylan Developers
 =========================


### PR DESCRIPTION
and fix link to Hannes' paper.  The first few publications shorts are unfortunately duplicated onto the main doc index page.  I dropped the oldest one off the list.