### PR TITLE
Change URL to improve git protocol security

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "sphinx-extensions"]
 	path = sphinx-extensions
-	url = git://github.com/dylan-lang/sphinx-extensions.git
+	url = https://github.com/dylan-lang/sphinx-extensions.git


### PR DESCRIPTION
This issue occurred as a result of GitHub's most recent improving Git protocol security, which was released on January 11, 2022, Final brownout.