### PR TITLE
Make the website repo an opendylan submodule

### DIFF
--- a/source/about/examples/hello_world.rst
+++ b/source/about/examples/hello_world.rst
@@ -29,8 +29,7 @@ The canonical "Hello World" program in Dylan.
    format-out("Hello!\n");
 
 
-.. hint:: The `dylan new application
-          <https://docs.opendylan.org/packages/dylan-tool/documentation/source/index.html#dylan-new-application>`_
+.. hint:: The `dylan new application </package/dylan-tool/index.html#dylan-new-application>`_
           command will create these files for you, along with a test suite and
           build files.
 

--- a/source/building-with-duim
+++ b/source/building-with-duim
@@ -1,0 +1,1 @@
+../../building-with-duim/source

--- a/source/community/index.rst
+++ b/source/community/index.rst
@@ -15,8 +15,8 @@ GitHub <https://gist.github.com>`_ and paste a link to it.
 .. _contribute:
 
 How to Contribute
-  The `Hacker Guide <https://opendylan.org/documentation/hacker-guide/>`_ has details on
-  how to contribute to the project.
+  The :doc:`Hacker Guide <hacker-guide/index>` has details on how to contribute
+  to the project.
 
 Report Bugs
   Bugs may be reported against the `opendylan repository`_ on GitHub. If you know the bug

--- a/source/conf.py
+++ b/source/conf.py
@@ -3,7 +3,7 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../sphinx-extensions/sphinxcontrib'))
+sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
 extensions = [
     'dylan.domain',
     'sphinx.ext.graphviz',

--- a/source/corba-guide
+++ b/source/corba-guide
@@ -1,0 +1,1 @@
+../../corba-guide/source

--- a/source/documentation/cheatsheets/collections.rst
+++ b/source/documentation/cheatsheets/collections.rst
@@ -160,8 +160,8 @@ Common Operations
 |                     |                              | has a particular key.                                |
 +---------------------+------------------------------+------------------------------------------------------+
 
-.. _<set>: https://opendylan.org/documentation/library-reference/collections/set.html
-.. _<bit-set>: https://opendylan.org/documentation/library-reference/collections/bit-set.html
-.. _<bit-vector>: https://opendylan.org/documentation/library-reference/collections/bit-vector.html
-.. _<byte-vector>: https://opendylan.org/documentation/library-reference/common-dylan/byte-vector.html
-.. _<string-table>: https://opendylan.org/documentation/library-reference/collections/table-extensions.html#collections:table-extensions:[string-table]
+.. _<set>: library-reference/collections/set.html
+.. _<bit-set>: library-reference/collections/bit-set.html
+.. _<bit-vector>: library-reference/collections/bit-vector.html
+.. _<byte-vector>: library-reference/common-dylan/byte-vector.html
+.. _<string-table>: library-reference/collections/table-extensions.html#collections:table-extensions:[string-table]

--- a/source/documentation/index.rst
+++ b/source/documentation/index.rst
@@ -8,7 +8,7 @@ Learn Dylan
 :doc:`../about/index`
     A quick overview of the language with examples of major features.
 
-:doc:`../opendylan/documentation/intro-dylan/source/index`
+:doc:`../intro-dylan/source/index`
     This tutorial is written primarily for those with solid programming
     experience in C++ or another object-oriented, static language. It
     provides a gentler introduction to Dylan than does the `Dylan Reference
@@ -17,15 +17,15 @@ Learn Dylan
 `Dylan Programming Guide`_ [`pdf <https://opendylan.org/books/dpg/DylanProgramming.pdf>`__] [`epub <https://opendylan.org/books/dpg/DylanProgramming.epub>`__]
     A book length Dylan tutorial.
 
-:doc:`../opendylan/documentation/getting-started-cli/source/index`
+:doc:`../getting-started-cli/source/index`
     Describes development using the Open Dylan command line tools
     and editor integration (like emacs). This is mainly for
     Linux, FreeBSD, and macOS users.
 
-:doc:`../opendylan/documentation/getting-started-ide/source/index`
+:doc:`../getting-started-ide/source/index`
     Describes Open Dylan's integrated development environment (Windows only).
 
-:doc:`../opendylan/documentation/building-with-duim/source/index`
+:doc:`../building-with-duim/source/index`
     Describes how to use DUIM (Dylan User Interface Manager),
     the portable window programming toolkit. (Windows only.)
 
@@ -35,15 +35,15 @@ References
 `Dylan Reference Manual`_ (`Errata`_)
     The official definition of the Dylan language and standard library.
 
-:doc:`../opendylan/documentation/library-reference/source/index`
+:doc:`../library-reference/source/index`
     Reference docs for core libraries packaged with Open Dylan.
 
-:doc:`../opendylan/documentation/duim-reference/source/index`
+:doc:`../duim-reference/source/index`
     Describes the libraries forming DUIM (Dylan User Interface Manager),
     the portable window programming toolkit. It complements
     Building Applications Using DUIM. (Currently Windows only.)
 
-:doc:`../opendylan/documentation/corba-guide/source/index`
+:doc:`../corba-guide/source/index`
     A tutorial and reference for CORBA interoperability using the Open
     Dylan ORB.
 
@@ -132,10 +132,10 @@ For Open Dylan Developers
 .. note:: Notes and materials useful to those working on Open Dylan itself or
           those who have an interest in the low level details.
 
-:doc:`../opendylan/documentation/hacker-guide/source/index`
+:doc:`../hacker-guide/source/index`
     A work in progress to help out people who are hacking on Open Dylan itself.
 
-:doc:`../opendylan/documentation/style-guide/source/index`
+:doc:`../style-guide/source/index`
     Notes and thoughts on how to format your Dylan code. This is the style
     guide that we aspire to adhere to in the Open Dylan sources.
 
@@ -143,7 +143,7 @@ For Open Dylan Developers
     A series of proposals for improvements to the Open Dylan
     implementation and related libraries.
 
-:doc:`../opendylan/documentation/release-notes/source/index`
+:doc:`../release-notes/source/index`
     Notes on new features and bug fixes in each release of Open Dylan.
 
 
@@ -159,14 +159,14 @@ For Open Dylan Developers
 
    cheatsheets/index
    Publications <publications>
-   ../opendylan/documentation/intro-dylan/source/index
+   ../intro-dylan/source/index
    ../news/index
-   ../opendylan/documentation/building-with-duim/source/index
-   ../opendylan/documentation/corba-guide/source/index
-   ../opendylan/documentation/duim-reference/source/index
-   ../opendylan/documentation/getting-started-ide/source/index
-   ../opendylan/documentation/library-reference/source/copyright
-   ../opendylan/documentation/man-pages/source/index
-   ../opendylan/documentation/release-notes/source/index
-   ../opendylan/documentation/sphinx-extensions/documentation/source/index
-   ../opendylan/documentation/style-guide/source/index
+   ../building-with-duim/source/index
+   ../corba-guide/source/index
+   ../duim-reference/source/index
+   ../getting-started-ide/source/index
+   ../library-reference/source/copyright
+   ../man-pages/source/index
+   ../release-notes/source/index
+   ../sphinx-extensions/documentation/source/index
+   ../style-guide/source/index

--- a/source/duim-reference
+++ b/source/duim-reference
@@ -1,0 +1,1 @@
+../../duim-reference/source

--- a/source/getting-started-cli
+++ b/source/getting-started-cli
@@ -1,0 +1,1 @@
+../../getting-started-cli/source

--- a/source/getting-started-ide
+++ b/source/getting-started-ide
@@ -1,0 +1,1 @@
+../../getting-started-ide/source

--- a/source/hacker-guide
+++ b/source/hacker-guide
@@ -1,0 +1,1 @@
+../../hacker-guide/source

--- a/source/index.rst
+++ b/source/index.rst
@@ -33,8 +33,8 @@ how to define libraries and modules right away.
 
 Then maybe try one of these more in-depth guides:
 
-* :doc:`opendylan/documentation/intro-dylan/source/index` provides a high-level
-  overview of language features.
+* :doc:`intro-dylan/source/index` provides a high-level overview of language
+  features.
 * `Dylan Programming Guide`_ is a book length Dylan tutorial.
 
 The `Dylan Reference Manual`_, besides being the official language definition,
@@ -79,7 +79,7 @@ articles, and all the library docs.
 
    Get Involved <community/index>
    Download <download/index>
-   Hacker Guide <opendylan/documentation/hacker-guide/source/index>
+   Hacker Guide <hacker-guide/source/index>
    Enhancement Proposals <proposals/index>
 
 .. toctree::
@@ -87,7 +87,7 @@ articles, and all the library docs.
    :hidden:
 
    Tour of Dylan <about/index>
-   Getting Started Guide <opendylan/documentation/getting-started-cli/source/index>
+   Getting Started Guide <getting-started-cli/source/index>
    Dylan Programming Guide <https://opendylan.org/books/dpg/>
 
 .. Note that the package/index reference below is not part of this
@@ -100,5 +100,5 @@ articles, and all the library docs.
 
    Dylan Reference Manual <https://opendylan.org/books/drm/>
    Package Docs <package/index>
-   Open Dylan Libraries <opendylan/documentation/library-reference/source/index>
+   Open Dylan Libraries <library-reference/source/index>
    All Documentation <documentation/index>

--- a/source/intro-dylan
+++ b/source/intro-dylan
@@ -1,0 +1,1 @@
+../../intro-dylan/source

--- a/source/library-reference
+++ b/source/library-reference
@@ -1,0 +1,1 @@
+../../library-reference/source

--- a/source/man-pages
+++ b/source/man-pages
@@ -1,0 +1,1 @@
+../../man-pages/source

--- a/source/news/2012/10/15/command-line-parser.rst
+++ b/source/news/2012/10/15/command-line-parser.rst
@@ -12,7 +12,7 @@ completely rewritten to
   * be far less verbose
   * have simplified usage
   * have automatic support for --help
-  * be `documented </documentation/library-reference/command-line-parser/index.html>`_
+  * be `documented </library-reference/command-line-parser/index.html>`_
 
 Testworks and the HTTP server are using the new library.  More
 enhancements coming soon.

--- a/source/news/2012/12/20/new-release.rst
+++ b/source/news/2012/12/20/new-release.rst
@@ -14,7 +14,7 @@ For a variety of reasons, we didn't get to carry out our plan for
 more frequent releases in 2012, but hope to have more frequent releases
 in 2013.
 
-While we have extensive `release notes <https://opendylan.org/documentation/release-notes/2012.1.html>`_,
+While we have extensive `release notes </release-notes/2012.1.html>`_,
 there are some important changes that we feel are worth calling out
 separately:
 

--- a/source/news/2013/07/11/new-release.rst
+++ b/source/news/2013/07/11/new-release.rst
@@ -9,7 +9,7 @@ Dear Dylan Hacker,
 
 It is a pleasure for us to announce a new release of Open Dylan.
 
-We have extensive `release notes <https://opendylan.org/documentation/release-notes/2013.1.html>`_,
+We have extensive `release notes </release-notes/2013.1.html>`_,
 but this release has been about iterative improvement rather than major changes.
 
 * A deadlock when using threads on x86-linux has been addressed.

--- a/source/news/2013/08/15/duim-gtk.rst
+++ b/source/news/2013/08/15/duim-gtk.rst
@@ -32,12 +32,12 @@ work to do on DUIM/Gtk. (We have started building a
 for the `hacker's guide`_, especially for working on Mac OS X.
 
 If you're interested in learning more or helping out, get
-in touch with us on `IRC or the mailing list`_!
+in touch with us on `chat or the mailing list`_!
 
-.. _DUIM: https://opendylan.org/documentation/building-with-duim/
-.. _IDE: https://opendylan.org/documentation/getting-started-ide/
+.. _DUIM: /building-with-duim/index.html
+.. _IDE: /getting-started-ide/index.html
 .. _sources/gtk: https://github.com/dylan-lang/opendylan/tree/master/sources/gtk
 .. _DUIM GTK+: https://github.com/dylan-lang/opendylan/tree/master/sources/duim/gtk
 .. _list of bugs: https://github.com/dylan-lang/opendylan/labels/lib-DUIM%20%2F%20Gtk
-.. _hacker's guide: https://opendylan.org/documentation/hacker-guide/duim/index.html
-.. _IRC or the mailing list: https://opendylan.org/community/
+.. _hacker's guide: /hacker-guide/duim/index.html
+.. _chat or the mailing list: /community/

--- a/source/news/index.rst
+++ b/source/news/index.rst
@@ -2,6 +2,37 @@
 News
 ****
 
+Website Revamp - 2023-07-07
+===========================
+
+The opendylan.org website has had a long overdue major overhaul. The goals of
+this revamp were:
+
+1. Enable better navigation between different sections of the website. For
+   example, when reading documentation in the Library Reference it should be
+   easy to navigate to the Hacker Guide or to package docs. Now everything is
+   accessible from the left sidebar (the ``:toctree:`` in reStructured Text
+   terminology).
+
+#. Improved accessibility. The old site had a very low contrast top navbar and
+   other low contrast elements. The new `Furo
+   <https://pradyunsg.me/furo/quickstart/>`_ theme has much better contrast
+   plus light and dark themes.
+
+#. Local table of contents in the right sidebar. Hooray `Furo
+   <https://pradyunsg.me/furo/quickstart/>`_!
+
+#. Integrated :doc:`package docs <../package/index>`.
+
+#. Simplicity! We're a small team so we want to avoid any extra maintenance
+   burden. To that end, we no longer use a Dylan-specific Sphinx theme or
+   templates. If it ain't in `Furo <https://pradyunsg.me/furo/quickstart/>`_,
+   we don't want it! :-)
+
+We'd love to hear feedback on the new site. You can `file a bug
+<https://github.com/dylan-lang/website/issues>`_ or `drop us a note on Matrix
+<https://app.element.io/#/room/#dylan-language:matrix.org>`_.
+
 :doc:`New release: 2022.1 </news/2022/11/28/new-release>` *- 2022-11-28*
   Open Dylan 2022.1 released!
 

--- a/source/release-notes
+++ b/source/release-notes
@@ -1,0 +1,1 @@
+../../release-notes/source

--- a/source/style-guide
+++ b/source/style-guide
@@ -1,0 +1,1 @@
+../../style-guide/source


### PR DESCRIPTION
Submodule in the website repo at documentation/website and adjust various references in the website docs to match that directory structure.

Also added a news item for the website revamp.