### PR TITLE
Use packages instead of being a submodule of opendylan

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "sphinx-extensions"]
-	path = sphinx-extensions
-	url = https://github.com/dylan-lang/sphinx-extensions.git

--- a/README.rst
+++ b/README.rst
@@ -3,70 +3,57 @@ This is the Open Dylan website.
 It is built using `Sphinx <https://www.sphinx-doc.org/>`_.  All content is
 written using ReStructured Text with Sphinx extensions.
 
-Preparation
-===========
+Installation
+============
 
-Installing system dependencies
-------------------------------
+Some system dependencies need to be satisfied first.  On a Debian-derivative
+this should work::
 
-Some system dependencies need to be satisfied first:
+    sudo apt install git graphviz make python3
 
-- Python 3 and its package manager pip3. (It may also be installed as just
-  "pip", but check whether that installs Python 2 packages.)
-- Git
-- Make
+Install a Python3 virtual environment and use ``pip`` rather than the ``apt``
+Python packages, which are sometimes very out-of-date. ::
 
-On a Debian-derivative, they're quite easy to fetch::
+    python3 -m venv /opt/python3-venv
+    export PATH=/opt/python3-venv/bin:${PATH}
+    pip install Sphinx furo
 
-    sudo apt install python3 python3-pip git make
+The next step is fetching the repository and its dependencies::
 
-Getting the source
-------------------
+    git clone https://github.com/dylan-lang/website.git
+    cd website
+    deft update    # Install Dylan package dependencies
 
-The next step is fetching the repository and its submodule::
+Building the site
+=================
 
-    git clone --recursive https://github.com/dylan-lang/website.git  # or your fork
+Simply run the :file:`update.sh` script, specifying where you want the HTML
+files to be generated::
 
-Note that for now the "opendylan" repository is a submodule and it (along with
-its own submodules) is rather large.
+    update.sh /tmp/opendylan.org
 
-Installing Sphinx and the Furo Theme
-------------------------------------
+The first time you run :file:`update.sh`, it will build the `gendoc
+<https://github.com/dylan-lang/gendoc>`_ executable, which takes a bit longer.
 
-Now you need the Python dependencies. The easiest way to do this is to use
-``pip3``::
+.. note:: Currently the downloads directory is still maintained by hand. When
+          building the live site the first time, copy the files from the old
+          location.
 
-    sudo pip3 install -U Sphinx furo
+Testing
+=======
 
-You may also need ``python-dateutil``.
+The generated site will be in the output directory you specified. Run a local
+server using that directory as a static site. For example::
 
-    sudo pip3 install python-dateutil
+    python3 -m http.server --directory /tmp/opendylan.org
 
-Building
-========
-
-Building the website is easy on a system with ``make``::
-
-    make html
-
-If you are on Windows, there is a ``make.bat`` as well. It currently requires
-that you run it with an argument::
-
-    make.bat html  # Best of luck! This hasn't been tested in ages.
-
-The generated site will be in ``build/html``. For the stylesheets and
-JavaScript to load correctly, we suggest running a local webserver
-pointing to this directory::
-
-    python3 -m http.server --directory build/html
-
-or you can eat our own Dylan dogfood and run our HTTP server! ::
+For bonus points, you can eat our own dogfood and run the Dylan HTTP server
+instead::
 
     git clone --recursive https://github.com/dylan-lang/http
     cd http
     make install
-    cd ...back to website dir...
-    http-server --directory build/html
+    http-server --directory /tmp/opendylan.org
 
 Link Validation
 ---------------

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,0 +1,16 @@
+{
+    "name": "website",
+    "version": "0.1.0",
+    "description": "The opendylan.org website and tools to build it.",
+    "contact": "dylan-lang@googlegroups.com",
+    "keywords": ["documentation"],
+    "dependencies": [],
+    "dev-dependencies": [
+        "dylan-reference-manual",
+        "dylan-programming-book",
+        "gendoc",
+        "opendylan",
+        "sphinx-extensions"
+    ],
+    "url": "https://github.com/dylan-lang/website"
+}

--- a/source/building-with-duim
+++ b/source/building-with-duim
@@ -1,1 +1,1 @@
-../../building-with-duim/source
+../_packages/opendylan/current/src/documentation/building-with-duim

--- a/source/community/index.rst
+++ b/source/community/index.rst
@@ -15,7 +15,7 @@ GitHub <https://gist.github.com>`_ and paste a link to it.
 .. _contribute:
 
 How to Contribute
-  The :doc:`Hacker Guide <../hacker-guide/index>` has details on how to
+  The :doc:`Hacker Guide <../hacker-guide/source/index>` has details on how to
   contribute to the project.
 
 Report Bugs

--- a/source/conf.py
+++ b/source/conf.py
@@ -3,7 +3,7 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../../sphinx-extensions/sphinxcontrib'))
+sys.path.insert(0, os.path.abspath('../_packages/sphinx-extensions/current/src/sphinxcontrib'))
 extensions = [
     'dylan.domain',
     'sphinx.ext.graphviz',
@@ -38,9 +38,5 @@ html_favicon = '_static/favicon.ico'
 templates_path = ['_templates']
 
 exclude_patterns = [
-    # Omit duplicate docs and docs in submodules...
     '**/sphinx_rtd_theme/**',
-    'opendylan/sources/**',
-    'opendylan/*.rst',
-    'opendylan/**/README.rst',
 ]

--- a/source/corba-guide
+++ b/source/corba-guide
@@ -1,1 +1,1 @@
-../../corba-guide/source
+../_packages/opendylan/current/src/documentation/corba-guide

--- a/source/documentation/index.rst
+++ b/source/documentation/index.rst
@@ -8,7 +8,7 @@ Learn Dylan
 :doc:`../about/index`
     A quick overview of the language with examples of major features.
 
-:doc:`../intro-dylan/index`
+:doc:`../intro-dylan/source/index`
     This tutorial is written primarily for those with solid programming
     experience in C++ or another object-oriented, static language. It
     provides a gentler introduction to Dylan than does the `Dylan Reference
@@ -17,15 +17,15 @@ Learn Dylan
 `Dylan Programming Guide`_ [`pdf <https://opendylan.org/books/dpg/DylanProgramming.pdf>`__] [`epub <https://opendylan.org/books/dpg/DylanProgramming.epub>`__]
     A book length Dylan tutorial.
 
-:doc:`../getting-started-cli/index`
+:doc:`../getting-started-cli/source/index`
     Describes development using the Open Dylan command line tools
     and editor integration (like emacs). This is mainly for
     Linux, FreeBSD, and macOS users.
 
-:doc:`../getting-started-ide/index`
+:doc:`../getting-started-ide/source/index`
     Describes Open Dylan's integrated development environment (Windows only).
 
-:doc:`../building-with-duim/index`
+:doc:`../building-with-duim/source/index`
     Describes how to use DUIM (Dylan User Interface Manager),
     the portable window programming toolkit. (Windows only.)
 
@@ -35,15 +35,15 @@ References
 `Dylan Reference Manual`_ (`Errata`_)
     The official definition of the Dylan language and standard library.
 
-:doc:`../library-reference/index`
+:doc:`../library-reference/source/index`
     Reference docs for core libraries packaged with Open Dylan.
 
-:doc:`../duim-reference/index`
+:doc:`../duim-reference/source/index`
     Describes the libraries forming DUIM (Dylan User Interface Manager),
     the portable window programming toolkit. It complements
     Building Applications Using DUIM. (Currently Windows only.)
 
-:doc:`../corba-guide/index`
+:doc:`../corba-guide/source/index`
     A tutorial and reference for CORBA interoperability using the Open
     Dylan ORB.
 
@@ -132,10 +132,10 @@ For Open Dylan Developers
 .. note:: Notes and materials useful to those working on Open Dylan itself or
           those who have an interest in the low level details.
 
-:doc:`../hacker-guide/index`
+:doc:`../hacker-guide/source/index`
     A work in progress to help out people who are hacking on Open Dylan itself.
 
-:doc:`../style-guide/index`
+:doc:`../style-guide/source/index`
     Notes and thoughts on how to format your Dylan code. This is the style
     guide that we aspire to adhere to in the Open Dylan sources.
 
@@ -143,7 +143,7 @@ For Open Dylan Developers
     A series of proposals for improvements to the Open Dylan
     implementation and related libraries.
 
-:doc:`../release-notes/index`
+:doc:`../release-notes/source/index`
     Notes on new features and bug fixes in each release of Open Dylan.
 
 
@@ -160,11 +160,11 @@ For Open Dylan Developers
    News <../news/index>
    Cheat Sheets <cheatsheets/index>
    Publications <publications>
-   Intro to Dylan <../intro-dylan/index>
-   CORBA Guide <../corba-guide/index>
-   DUIM Guide <../building-with-duim/index>
-   DUIM Reference <../duim-reference/index>
-   Getting Started / IDE <../getting-started-ide/index>
-   Release Notes <../release-notes/index>
+   Intro to Dylan <../intro-dylan/source/index>
+   CORBA Guide <../corba-guide/source/index>
+   DUIM Guide <../building-with-duim/source/index>
+   DUIM Reference <../duim-reference/source/index>
+   Getting Started / IDE <../getting-started-ide/source/index>
+   Release Notes <../release-notes/source/index>
    Sphinx Extensions <../../sphinx-extensions/documentation/source/index>
-   Style Guide <../style-guide/index>
+   Style Guide <../style-guide/source/index>

--- a/source/duim-reference
+++ b/source/duim-reference
@@ -1,1 +1,1 @@
-../../duim-reference/source
+../_packages/opendylan/current/src/documentation/duim-reference

--- a/source/getting-started-cli
+++ b/source/getting-started-cli
@@ -1,1 +1,1 @@
-../../getting-started-cli/source
+../_packages/opendylan/current/src/documentation/getting-started-cli

--- a/source/getting-started-ide
+++ b/source/getting-started-ide
@@ -1,1 +1,1 @@
-../../getting-started-ide/source
+../_packages/opendylan/current/src/documentation/getting-started-ide

--- a/source/hacker-guide
+++ b/source/hacker-guide
@@ -1,1 +1,1 @@
-../../hacker-guide/source
+../_packages/opendylan/current/src/documentation/hacker-guide

--- a/source/index.rst
+++ b/source/index.rst
@@ -33,13 +33,13 @@ how to define libraries and modules right away.
 
 Then move on to one of these in-depth guides:
 
-* :doc:`intro-dylan/index` provides a high-level overview of language
+* :doc:`intro-dylan/source/index` provides a high-level overview of language
   features.
 * `Dylan Programming Guide`_ is a book length Dylan tutorial.
 
 The `Dylan Reference Manual`_, besides being the official language definition,
 has an excellent, very brief `introduction
-<https://opendylan.org/books/drm/Introduction>`_ describing the language
+<books/drm/Introduction>`_ describing the language
 background and goals.
 
 Or explore :doc:`all the docs <documentation/index>`, including cheat sheets,
@@ -83,7 +83,7 @@ articles, and all the library docs.
 
    Get Involved <community/index>
    Download <download/index>
-   Hacker Guide <hacker-guide/index>
+   Hacker Guide <hacker-guide/source/index>
    Enhancement Proposals <proposals/index>
 
 .. toctree::
@@ -91,7 +91,7 @@ articles, and all the library docs.
    :hidden:
 
    Tour of Dylan <about/index>
-   Getting Started Guide <getting-started-cli/index>
+   Getting Started Guide <getting-started-cli/source/index>
    Dylan Programming Guide <https://opendylan.org/books/dpg/>
    Dylan Playground <https://play.opendylan.org>
 
@@ -105,6 +105,6 @@ articles, and all the library docs.
 
    Dylan Reference Manual <https://opendylan.org/books/drm/>
    Package Docs <package/index>
-   Open Dylan Libraries <library-reference/index>
+   Open Dylan Libraries <library-reference/source/index>
    All Documentation <documentation/index>
    Full Index <genindex>

--- a/source/intro-dylan
+++ b/source/intro-dylan
@@ -1,1 +1,1 @@
-../../intro-dylan/source
+../_packages/opendylan/current/src/documentation/intro-dylan

--- a/source/library-reference
+++ b/source/library-reference
@@ -1,1 +1,1 @@
-../../library-reference/source
+../_packages/opendylan/current/src/documentation/library-reference

--- a/source/man-pages
+++ b/source/man-pages
@@ -1,1 +1,1 @@
-../../man-pages/source
+../_packages/opendylan/current/src/documentation/man-pages

--- a/source/release-notes
+++ b/source/release-notes
@@ -1,1 +1,1 @@
-../../release-notes/source
+../_packages/opendylan/current/src/documentation/release-notes

--- a/source/sphinx-extensions
+++ b/source/sphinx-extensions
@@ -1,0 +1,1 @@
+../_packages/sphinx-extensions/current/src

--- a/source/style-guide
+++ b/source/style-guide
@@ -1,1 +1,1 @@
-../../style-guide/source
+../_packages/opendylan/current/src/documentation/style-guide

--- a/update-opendylan.org.sh
+++ b/update-opendylan.org.sh
@@ -7,19 +7,15 @@ exec > $logfile 2>&1
 
 exe_dir="$(realpath $(dirname $0))"
 
-repo_dir=/root/deploy-opendylan.org
-gendoc_exe=${repo_dir}/gendoc/_build/bin/gendoc
 dest_dir=/var/www/opendylan.org
 
-# Update opendylan and website submodule first so we get any changes
-# to the update.sh script.
-cd ${repo_dir}/opendylan
+# Update the repo first so we get any changes to the update.sh script,
+# dependencies, etc.
 git pull --rebase origin master
-git submodule update --init --recursive
 
-${exe_dir}/update.sh "${dest_dir}" "${repo_dir}" "${gendoc_exe}"
+${exe_dir}/update.sh "${dest_dir}"
 
-echo "Done updating opendylan.org"
+echo "Done updating opendylan.org in ${dest_DIR}."
 bzip2 $logfile
 # Keep 10 days of logs.
 find /var/log -name 'update-opendylan.org.*' -mtime +10 -print -exec rm {} \;

--- a/update.sh
+++ b/update.sh
@@ -1,42 +1,56 @@
 #!/bin/bash -xe
 
-# This script builds the opendylan.org website. It does a clean build
-# each time and copies files to ${dest_dir}, meaning that there could
-# be cruft left around in ${dest_dir}. Might want to fix that some day.
+# This script builds the opendylan.org website. It does a clean build of the
+# docs each time and copies files to ${dest_dir}, meaning that there could be
+# cruft left around in ${dest_dir}. Might want to fix that some day.
 
 # /var/www/opendylan.org/downloads is handled specially. New versions of Open
 # Dylan should be copied there by hand, or ... we could stop doing that.
 
-if [[ $# -ne 3 ]]; then
-    echo "Usage: `basename $0` dest_dir repo_dir gendoc_exe"
+# Note the -e in the #! line above causes this script to abort on any command
+# failure.
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: `basename $0` dest_dir"
     echo "  dest_dir:    Directory in which to place the built website documents."
     echo "               Example: /var/www/opendylan.org"
-    echo "  repo_dir:    Directory in which opendylan, drm, and dpg repos live."
-    echo "  gendoc_exe:  Path to the gendoc executable."
     exit 2
 fi
 
+# Get latest gendoc, DRM, DPG, etc, as specified in dylan-package.json.
+echo "Updating the Dylan workspace to get latest packages..."
+dylan update
+dylan build gendoc
+
+website_dir=$(realpath $(dirname "$0"))
+
 dest_dir=$(realpath "$1")
-repo_dir=$(realpath "$2")
-gendoc_exe=$(realpath "$3")
+if [[ ! -d "$dest_dir" ]]; then
+    echo "dest_dir ${dest_dir} doesn't exist, aborting."
+    exit 2
+fi
 
-# Not sure if necessary yet...
-#mkdir -p ${dest_dir}/_plantuml
+gendoc_exe=${website_dir}/_build/bin/gendoc
 
-echo "Generating package docs..."
-gendoc_work_dir=$(mktemp -d gendoc-XXXX) # git clones go here
-gendoc_output_dir=${repo_dir}/opendylan/documentation/website/source
-cd ${gendoc_work_dir}
+# Packages are downloaded here.
+gendoc_work_dir=$(mktemp -d gendoc-XXXX)
+
+# Doc for each package is generated in
+# ${gendoc_output_dir}/package/<package-name>
+gendoc_output_dir=${website_dir}/source
+echo "Generating package docs in ${gendoc_output_dir}..."
+
 rm -rf ${gendoc_output_dir}/package
 ${gendoc_exe} -o ${gendoc_output_dir}
 
 echo "Building website..."
-cd ${repo_dir}/opendylan/documentation/website
-make clean
 make html
 rsync -avz build/html/ ${dest_dir}
 
 echo "Updating DRM files..."
-cd ${repo_dir}/dylan-reference-manual
-git pull --rebase origin master
-rsync -avz source/  /var/www/opendylan.org/books/drm
+mkdir -p ${dest_dir}/books/drm
+rsync -avz _packages/dylan-reference-manual/current/src/source/  ${dest_dir}/books/drm
+
+echo "Updating DPG files..."
+mkdir -p ${dest_dir}/books/dpg
+rsync -avz _packages/dylan-programming-book/current/src/source/  ${dest_dir}/books/dpg


### PR DESCRIPTION
Having the website repo be a submodule of opendylan and linking into its documentation directory was kind of a quick fix when opendylan.org was being revamped to use Furo theme and integrate the web site and the documentation into a single index. It was problematic because it meant updating the website submodule every time something changed, which is cumbersome and easy to forget.

With this change, the web site can deploy from the master branch and the documentation bundled with Open Dylan will update whenever a new version of opendylan is published in the pacman catalog.

A bug in update.sh was fixed: files are copied to $dest_dir instead of to /var/www/opendylan.org.

The site generated by this change is live on opendylan.org. There are a couple of warnings that haven't been addressed yet, but they're not serious, and update-opendylan.org.sh has not yet been tested or installed on opendylan.org.