### PR TITLE
CD: Build website documentation and deploy to GH pages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docs-build-linkcheck-deploy.yml
+++ b/.github/workflows/docs-build-linkcheck-deploy.yml
@@ -1,0 +1,50 @@
+name: Build and deploy docs
+
+on:
+  push:
+    # all branches
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+# https://github.com/JamesIves/github-pages-deploy-action#readme
+permissions:
+    contents: write
+
+jobs:
+
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Python package dependencies
+        uses: BSFishy/pip-action@v1
+        with:
+          packages: |
+            Sphinx
+            furo
+
+      - name: Build destination directory
+        run: mkdir opendylan.org
+
+      - name: Install Opendylan
+        uses: dylan-lang/install-opendylan@v3
+
+      - name: Execute update script
+        run: ./update.sh opendylan.org
+
+      - name: Bypassing Jekyll on GH Pages
+        run: sudo touch opendylan.org/.nojekyll
+
+      - name: Deploy documents to GH pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: opendylan.org

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,26 @@
-build
-\#*
+# backup files
 *~
+*.bak
+.DS_Store
+\#*
+
+# project file
+*.hdp
+
+# documentation build directory
+build/
+
+# compiler build directory
+_build/
+
+# dylan tool package cache
+_packages/
+
+# package registry folder
+/registry/
+
+# packages downloaded
+gendoc-scratch-dir/
+
+# docs for each package
+source/package/

--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,11 @@ The next step is fetching the repository and its dependencies::
 Building the site
 =================
 
+First create the destination directory, for instance
+:file:`/tmp/opendylan.org`::
+
+    mkdir /tmp/opendylan.org
+
 Simply run the :file:`update.sh` script, specifying where you want the HTML
 files to be generated::
 


### PR DESCRIPTION
On push build documentation executing 'update.sh' script and deploy the website to GH pages.